### PR TITLE
Revert "chore: add requirements.txt"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,3 @@ All code is licensed under the terms of the MIT license.
    ```
    pip3 install -r requirements.txt
    ```
-
-

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ All code is licensed under the terms of the MIT license.
 -  Python 3.7
 
 # Requirements
-   ```python
+   ```
    pip3 install -r requirements.txt
    ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is the source code for my blog post [Custom Layers in Core ML](http://machi
 All code is licensed under the terms of the MIT license.
 
 # Prerequisites
--  Python 3.6
+-  Python 3.7
 
 # Requirements
    ```python

--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 This is the source code for my blog post [Custom Layers in Core ML](http://machinethink.net/blog/coreml-custom-layers/).
 
 All code is licensed under the terms of the MIT license.
+
+# Prerequisites
+-  Python 3.6
+
+# Requirements
+   ```python
+   pip3 install -r requirements.txt
+   ```
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-python==3.7
 keras==2.2.4
-tensorflow==2.0.0
+tensorflow==1.15.0
+Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+coremltools
 keras==2.2.4
 tensorflow==1.15.0
 Pillow


### PR DESCRIPTION
I'm very sorry for the revert of hollance/CoreML-Custom-Layers#6. There are still some problems when i re-run this code with existing version of requirements. Last time i could run through because I made some changes to the `tensorflow` manually. Also, it's not very complete. I make some modify, setting `tensorflow==1.15.0`, putting `python 3.6` in `README.md`, adding `coremltools` and `Pillow` in `requirements.txt`.  This time I am sure it will work well.